### PR TITLE
Support passing sitemap: :robots and string paths

### DIFF
--- a/lib/spidr/agent.rb
+++ b/lib/spidr/agent.rb
@@ -223,9 +223,7 @@ module Spidr
         initialize_robots
       end
 
-      if options.fetch(:sitemap,false)
-        initialize_sitemap
-      end
+      initialize_sitemap(options)
 
       yield self if block_given?
     end

--- a/spec/agent/sitemap_spec.rb
+++ b/spec/agent/sitemap_spec.rb
@@ -5,6 +5,45 @@ require 'spidr/agent'
 
 describe Agent do
   describe "sitemap" do
+    context "parh from sitemap option" do
+      include_context "example App"
+
+      subject { described_class.new(host: host, sitemap: 'my-sitemap.xml') }
+
+      app do
+        before do
+          content_type 'application/xml'
+        end
+
+        get '/my-sitemap.xml' do
+          <<-SITEMAP_XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url>
+               <loc>http://example.com/</loc>
+            </url>
+             <url>
+                <loc>http://example.com/some-path</loc>
+             </url>
+          </urlset>
+          SITEMAP_XML
+        end
+      end
+
+      before do
+        stub_request(:any, /#{Regexp.escape(host)}/).to_rack(app)
+      end
+
+      it 'should fetch all URLs in sitemap' do
+        urls = subject.sitemap_urls('http://example.com')
+        expected = [
+          URI('http://example.com/'),
+          URI('http://example.com/some-path')
+        ]
+        expect(urls).to eq(expected)
+      end
+    end
+
     context "from common sitemap index path" do
       include_context "example App"
 


### PR DESCRIPTION
"fancy" interface
```ruby
Spidr.site(url, sitemap: :robots) # check /robots.txt
```

Support non-default locations that aren't listed in `/robots.txt`, the [sitemap protocol](https://www.sitemaps.org/protocol.html#location) allows Sitemaps to be "scoped" under a path
```ruby
Spidr.site(url, sitemap: '/catalog/sitemap.xml')
```